### PR TITLE
Shape of luminous region directly specified in SimParms

### DIFF
--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -2,9 +2,14 @@ SimParms {
     numMinBiasEvents 140      // Number of pile-up events
     bunchSpacingNs 25
     
-    zErrorCollider 70         // mm
-    rphiErrorCollider 5       // mm
+    // Luminous region used in analysis
+    lumiRegZError                   70     // mm
+    lumiRegRError                   0      // mm
+    lumiRegShape                    Flat   // Choose among { Ponctual, Flat, Gaussian }
+    lumiRegShapeInMatBudgetAnalysis Ponctual
+
     useIPConstraint 0
+    rphiErrorCollider 5      // mm
     
     ptCost 0                  // CHF / cm^2
     stripCost 0               // CHF / cm^2

--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -2,11 +2,10 @@ SimParms {
     numMinBiasEvents 140      // Number of pile-up events
     bunchSpacingNs 25
     
-    // Luminous region used in analysis
+    // Luminous region used in analysis (always on (Z) axis, and Z centered on 0)
     lumiRegZError                   70     // mm
-    lumiRegRError                   0      // mm
-    lumiRegShape                    Flat   // Choose among { Ponctual, Flat, Gaussian }
-    lumiRegShapeInMatBudgetAnalysis Ponctual
+    lumiRegShape                    flat   // Choose among { ponctual, flat, gaussian }
+    lumiRegShapeInMatBudgetAnalysis ponctual
 
     useIPConstraint 0
     rphiErrorCollider 5      // mm

--- a/config/stdinclude/CMS_Phase2/SimParms
+++ b/config/stdinclude/CMS_Phase2/SimParms
@@ -2,11 +2,12 @@ SimParms {
     numMinBiasEvents 140      // Number of pile-up events
     bunchSpacingNs 25
     
-    // Luminous region used in analysis (always on (Z) axis, and Z centered on 0)
+    // Luminous region used in analysis (IP always on (Z) axis, with Z centered around 0)
     lumiRegZError                   70     // mm
-    lumiRegShape                    flat   // Choose among { ponctual, flat, gaussian }
-    lumiRegShapeInMatBudgetAnalysis ponctual
+    lumiRegShape                    flat   // Choose among { spot, flat, gaussian }
+    lumiRegShapeInMatBudgetAnalysis spot
 
+    // Adds IP to the track with corresponding resolution
     useIPConstraint 0
     rphiErrorCollider 5      // mm
     

--- a/include/Analyzer.hh
+++ b/include/Analyzer.hh
@@ -446,8 +446,10 @@ namespace insur {
     std::vector<TObject> savingGeometryV; // Vector of ROOT objects to be saved
     std::vector<TObject> savingMaterialV; // Vector of ROOT objects to be saved
 
-    Material findAllHits(MaterialBudget& mb, MaterialBudget* pm, Track& track);
+    const XYZVector getLuminousRegion();
+    const XYZVector getLuminousRegionInMatBudgetAnalysis();
 
+    Material findAllHits(MaterialBudget& mb, MaterialBudget* pm, Track& track);
 
     void computeDetailedWeights(std::vector<std::vector<ModuleCap> >& tracker, std::map<std::string, SummaryTable>& weightTables, bool byMaterial);
     virtual Material analyzeModules(std::vector<std::vector<ModuleCap> >& tr, Track& track,

--- a/include/SimParms.hh
+++ b/include/SimParms.hh
@@ -14,7 +14,7 @@
 #include "IrradiationMapsManager.hh"
 #include "Visitable.hh"
 
-//typedef std::map<std::pair<int,int>, double> IrradiationMap;
+enum LumiRegShape { PONCTUAL, FLAT, GAUSSIAN };
 
 class SimParms : public PropertyObject, public Buildable, public Visitable {
 
@@ -28,7 +28,13 @@ public:
 
   ReadonlyProperty<int, NoDefault> zErrorCollider;
   ReadonlyProperty<int, NoDefault> rphiErrorCollider;
+  //ReadonlyProperty<double, NoDefault> lumiRegZError;
+  //ReadonlyProperty<double, NoDefault> lumiRegRError;
+  ReadonlyProperty<LumiRegShape, NoDefault> lumiRegShape;
+  ReadonlyProperty<LumiRegShape, NoDefault> lumiRegShapeInMatBudgetAnalysis;
+
   ReadonlyProperty<bool, NoDefault> useIPConstraint;
+  ReadonlyProperty<double, NoDefault> rphiErrorCollider;
 
   ReadonlyProperty<int, NoDefault> ptCost;
   ReadonlyProperty<int, NoDefault> stripCost;
@@ -49,6 +55,8 @@ public:
   PropertyNode<std::string> taggedTracking;
 
   void build();
+
+  const XYZVector getLuminousRegion() const;
 
   void addIrradiationMapFile(std::string path);
 

--- a/include/SimParms.hh
+++ b/include/SimParms.hh
@@ -26,10 +26,7 @@ public:
   ReadonlyProperty<int, NoDefault> numMinBiasEvents;
   ReadonlyProperty<int, NoDefault> bunchSpacingNs;
 
-  ReadonlyProperty<int, NoDefault> zErrorCollider;
-  ReadonlyProperty<int, NoDefault> rphiErrorCollider;
-  //ReadonlyProperty<double, NoDefault> lumiRegZError;
-  //ReadonlyProperty<double, NoDefault> lumiRegRError;
+  ReadonlyProperty<double, NoDefault> lumiRegZError;
   ReadonlyProperty<LumiRegShape, NoDefault> lumiRegShape;
   ReadonlyProperty<LumiRegShape, NoDefault> lumiRegShapeInMatBudgetAnalysis;
 
@@ -55,8 +52,6 @@ public:
   PropertyNode<std::string> taggedTracking;
 
   void build();
-
-  const XYZVector getLuminousRegion() const;
 
   void addIrradiationMapFile(std::string path);
 

--- a/include/SimParms.hh
+++ b/include/SimParms.hh
@@ -14,7 +14,7 @@
 #include "IrradiationMapsManager.hh"
 #include "Visitable.hh"
 
-enum LumiRegShape { PONCTUAL, FLAT, GAUSSIAN };
+enum LumiRegShape { SPOT, FLAT, GAUSSIAN };
 
 class SimParms : public PropertyObject, public Buildable, public Visitable {
 

--- a/include/Track.hh
+++ b/include/Track.hh
@@ -73,13 +73,6 @@ public:
   //! Simulate efficiency by changing some active hits to non-active hits (passive)
   void addEfficiency();
 
-  /*
-  //! Simulate non-pixel efficiency by changing some active non-pixel hits to non-active hits (passive)
-  void addNonPixelEfficiency(double efficiency);
-
-  //! Simulate pixel efficiency by changing some active pixel hits to non-active hits (passive)
-  void addPixelEfficiency(double efficiency);*/
-
   //! Set track polar angle - theta, azimuthal angle - phi, particle transverse momentum - pt (signed: + -> particle in-out, - -> particle out-in)
   const Polar3DVector& setThetaPhiPt(const double& newTheta, const double& newPhi, const double& newPt);
 

--- a/include/Track.hh
+++ b/include/Track.hh
@@ -77,7 +77,7 @@ public:
   const Polar3DVector& setThetaPhiPt(const double& newTheta, const double& newPhi, const double& newPt);
 
   //! Set track origin
-  const XYZVector& setOrigin(const double& X, const double& Y, const double& Z) {m_origin.SetCoordinates(X,Y,Z); return m_origin;}
+  void setOrigin(const XYZVector& origin) { m_origin = origin; }
 
   //! Re-set transverse momentum + resort hits (if changing direction) + initiate recalc of cov matrices + prune hits (otherwise they may not lie on the new track, originally found at high pT limit)
   void resetPt(double newPt);

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -167,6 +167,7 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
 
     // TO DO: Add proper parametrization for shape of luminous region
     track.setOrigin(0., 0., 70.*(myDice.Rndm()*2.-1.));
+    std::cout << "Analysis resolution: myDice.Rndm() = " << myDice.Rndm() << std::endl;
 
     // Assign material to the track
     tmp = findAllHits(mb, pm, track);

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -89,9 +89,9 @@ namespace insur {
     const double zError = simParms.lumiRegZError();
 
     double dz = 0.;
-    if (lumiShape == LumiRegShape::PONCTUAL) dz = 0.;
+    if (lumiShape == LumiRegShape::SPOT) dz = 0.;
     else if (lumiShape == LumiRegShape::FLAT) dz = (myDice.Rndm() * 2. - 1.) * zError;
-    else if (lumiShape == LumiRegShape::GAUSSIAN) dz = myDice.Gaus(0, zError);
+    else if (lumiShape == LumiRegShape::GAUSSIAN) dz = myDice.Gaus(0., zError);
     else logERROR("Shape of luminous region specified in SimParms is not supported.");
 
     // IP position
@@ -106,7 +106,7 @@ namespace insur {
   const XYZVector Analyzer::getLuminousRegionInMatBudgetAnalysis() {
     const auto& simParms = SimParms::getInstance();
     const LumiRegShape& lumiShape = simParms.lumiRegShapeInMatBudgetAnalysis();
-    if (lumiShape != LumiRegShape::PONCTUAL) logERROR("Non-ponctual IP in Material Budget Analysis not supported.");
+    if (lumiShape != LumiRegShape::SPOT) logERROR("Non-ponctual IP in Material Budget Analysis not supported.");
 
     // IP position
     return XYZVector(0., 0., 0.); 

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -72,12 +72,18 @@ namespace insur {
 
   // private
 
-
+  /* Get shape of luminous region, used for all analysis (except Material Budget Analysis).
+   * IP is always assumed to be on the (Z) axis.
+   * Shape of luminous region in Z is defined by user in SimParms cfg files.
+   * Shape of luminous region in Z is always assumed to be centered around Z = 0.
+   * return: XYZVector defining the IP position (in CMS official frame of reference).
+   */
   const XYZVector Analyzer::getLuminousRegion() {
+    // IP is always assumed to be on the (Z) axis.
     const double dx = 0.;
     const double dy = 0.;
 
-    
+    // Compute dz according to specification in SimParms cfg files.
     const auto& simParms = SimParms::getInstance();
     const LumiRegShape& lumiShape = simParms.lumiRegShape();
     const double zError = simParms.lumiRegZError();
@@ -88,13 +94,21 @@ namespace insur {
     else if (lumiShape == LumiRegShape::GAUSSIAN) dz = myDice.Gaus(0, zError);
     else logERROR("Shape of luminous region specified in SimParms is not supported.");
 
+    // IP position
     return XYZVector(dx, dy, dz); 
   }
 
+
+  /* Get shape of luminous region, used for Material Budget analysis.
+   * IP = (0,0,0) is making sense for MB analysis.
+   * return: XYZVector defining the IP position (in CMS official frame of reference).
+   */
   const XYZVector Analyzer::getLuminousRegionInMatBudgetAnalysis() {
     const auto& simParms = SimParms::getInstance();
     const LumiRegShape& lumiShape = simParms.lumiRegShapeInMatBudgetAnalysis();
     if (lumiShape != LumiRegShape::PONCTUAL) logERROR("Non-ponctual IP in Material Budget Analysis not supported.");
+
+    // IP position
     return XYZVector(0., 0., 0.); 
   }
 
@@ -359,7 +373,6 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
 
     int nTracks;
     double etaStep, z0, eta, theta, phi;
-    //double zError = simParms.lumiRegZError();
 
     // prepare etaStep, phiStep, nTracks, nScans
     if (etaSteps > 1) etaStep = getEtaMaxTrigger() / (double)(etaSteps - 1);
@@ -374,7 +387,6 @@ void Analyzer::createTaggedTrackCollection(std::vector<MaterialBudget*> material
     // Loop over nTracks (eta range [0, getEtaMaxTrigger()])
     for (int i_eta = 0; i_eta < nTracks; i_eta++) {
       phi = myDice.Rndm() * M_PI * 2.0;
-      //z0 = myDice.Gaus(0, zError);
 
       Track track;
       eta = i_eta * etaStep;

--- a/src/AnalyzerVisitors/TriggerProcessorBandwidth.cc
+++ b/src/AnalyzerVisitors/TriggerProcessorBandwidth.cc
@@ -112,7 +112,7 @@ bool AnalyzerHelpers::isModuleInEtaSector(const SimParms& simParms, const Tracke
   double etaCut = simParms.triggerEtaCut();
   double etaSlice = etaCut*2 / numProcEta;
   double maxR = tracker.maxR();
-  double zError = simParms.zErrorCollider();
+  double zError = simParms.lumiRegZError();
   double eta = etaSlice*etaSector-etaCut;    
 
   double modMinZ = module.minZ();

--- a/src/SimParms.cc
+++ b/src/SimParms.cc
@@ -2,7 +2,7 @@
 #include "Units.hh"
 #include "MainConfigHandler.hh"
 
-define_enum_strings(LumiRegShape) = { "ponctual", "flat", "gaussian" };
+define_enum_strings(LumiRegShape) = { "spot", "flat", "gaussian" };
 
 //
 // Method constructing static instance of this class

--- a/src/SimParms.cc
+++ b/src/SimParms.cc
@@ -2,6 +2,8 @@
 #include "Units.hh"
 #include "MainConfigHandler.hh"
 
+define_enum_strings(LumiRegShape) = { "ponctual", "flat", "gaussian" };
+
 //
 // Method constructing static instance of this class
 //
@@ -66,6 +68,23 @@ void SimParms::build() {
 
   zErrorCollider.scaleByUnit(Units::mm);
   rphiErrorCollider.scaleByUnit(Units::mm);
+}
+
+const XYZVector SimParms::getLuminousRegion() const {
+  const double dx = lumiRegRError() / sqrt(2.);
+  const double dy = dx;
+
+  double dz = 0.;
+  if (lumiRegShape() == LumiRegShape::PONCTUAL) dz = 0.;
+  else if (lumiRegShape() == LumiRegShape::FLAT) dz = (myDice.Rndm() * 2. - 1.) * lumiRegZError();
+  else if (lumiRegShape() == LumiRegShape::GAUSSIAN) dz = myDice.Gaus(0, lumiRegZError());
+
+  return XYZVector(dx, dy, dz); 
+}
+
+const XYZVector SimParms::getLuminousRegionInMatBudgetAnalysis() const {
+  if (lumiRegShapeInMatBudgetAnalysis() != LumiRegShape::PONCTUAL) logERROR("Non-ponctual IP in Material Budget Analysis not supported.");
+  return XYZVector(0., 0., 0.); 
 }
 
 void SimParms::addIrradiationMapFile(std::string path) {

--- a/src/SimParms.cc
+++ b/src/SimParms.cc
@@ -19,9 +19,11 @@ SimParms& SimParms::getInstance()
 SimParms::SimParms() :
     numMinBiasEvents("numMinBiasEvents", parsedAndChecked()),
     bunchSpacingNs("bunchSpacingNs", parsedAndChecked()),
-    zErrorCollider("zErrorCollider", parsedAndChecked()),
-    rphiErrorCollider("rphiErrorCollider", parsedAndChecked()),
+    lumiRegZError("lumiRegZError", parsedAndChecked()),
+    lumiRegShape("lumiRegShape", parsedAndChecked()),
+    lumiRegShapeInMatBudgetAnalysis("lumiRegShapeInMatBudgetAnalysis", parsedAndChecked()),
     useIPConstraint("useIPConstraint", parsedAndChecked()),
+    rphiErrorCollider("rphiErrorCollider", parsedAndChecked()),
     ptCost("ptCost", parsedAndChecked()),
     stripCost("stripCost", parsedAndChecked()),
     triggerEtaCut("triggerEtaCut", parsedAndChecked()),
@@ -57,7 +59,7 @@ void SimParms::build() {
   bool nonZero = true;
   if (useIPConstraint()) {
 
-    if (zErrorCollider()==0)    nonZero = false;
+    if (lumiRegZError()==0)    nonZero = false;
     if (rphiErrorCollider()==0) nonZero = false;
   }
   if (!nonZero) throw PathfulException("IP constraint required, but errors on beam spot set to zero in R-Phi/Z!" , "SimParms");
@@ -66,25 +68,8 @@ void SimParms::build() {
   // Set expected default units
   magField.scaleByUnit(Units::T);
 
-  zErrorCollider.scaleByUnit(Units::mm);
+  lumiRegZError.scaleByUnit(Units::mm);
   rphiErrorCollider.scaleByUnit(Units::mm);
-}
-
-const XYZVector SimParms::getLuminousRegion() const {
-  const double dx = lumiRegRError() / sqrt(2.);
-  const double dy = dx;
-
-  double dz = 0.;
-  if (lumiRegShape() == LumiRegShape::PONCTUAL) dz = 0.;
-  else if (lumiRegShape() == LumiRegShape::FLAT) dz = (myDice.Rndm() * 2. - 1.) * lumiRegZError();
-  else if (lumiRegShape() == LumiRegShape::GAUSSIAN) dz = myDice.Gaus(0, lumiRegZError());
-
-  return XYZVector(dx, dy, dz); 
-}
-
-const XYZVector SimParms::getLuminousRegionInMatBudgetAnalysis() const {
-  if (lumiRegShapeInMatBudgetAnalysis() != LumiRegShape::PONCTUAL) logERROR("Non-ponctual IP in Material Budget Analysis not supported.");
-  return XYZVector(0., 0., 0.); 
 }
 
 void SimParms::addIrradiationMapFile(std::string path) {

--- a/src/Track.cc
+++ b/src/Track.cc
@@ -499,33 +499,6 @@ void Track::addEfficiency() {
   }
 }
 
-/*
-//
-// Simulate efficiency by changing some active non-pixel hits to non-active hits (passive)
-//
-void Track::addNonPixelEfficiency(double efficiency) {
-
-  for (auto& iHit : m_hits) {
-
-    if (iHit->isActive() && !iHit->isPixel()) {
-      if ((double(random())/RAND_MAX)>efficiency) iHit->setAsPassive(); // This hit is LOST
-    }
-  }
-}
-
-//
-// Simulate efficiency by changing some active pixel hits to non-active hits (passive)
-//
-void Track::addPixelEfficiency(double efficiency) {
-
-  for (auto& iHit : m_hits) {
-
-    if (iHit->isActive() && iHit->isPixel()) {
-      if ((double(random())/RAND_MAX)>efficiency) iHit->setAsPassive(); // This hit is LOST
-    }
-  }
-  }*/
-
 //
 // Set track polar angle - theta, azimuthal angle - phi, particle transverse momentum - pt
 // (magnetic field obtained automatically from SimParms singleton class)Setter for the track azimuthal angle.


### PR DESCRIPTION
The shape of the luminous region can now be directly specified in SimParms, instead of being hardcoded in Analyzer.

Present choice is IP = (0, 0, U[-70, 70]) for all analysis, except MB analysis which uses IP = (0,0,0).

NB: Shape of luminous region for trigger studies is switched here from Gaussian(0,70) to U[-70, 70].